### PR TITLE
[fix] Use env var TESLA_VIN, ! VIN

### DIFF
--- a/standalone/start_tesla_ble_mqtt.sh
+++ b/standalone/start_tesla_ble_mqtt.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # fill these values according to your settings #############
-VIN=""
+TESLA_VIN=""
 MQTT_IP=127.0.0.1
 MQTT_PORT=1883
 MQTT_USER=""
@@ -34,7 +34,7 @@ docker volume create tesla_ble_mqtt
 
 echo "Start main docker container with configuration Options:"
 
-echo TESLA_VIN=$VIN
+echo TESLA_VIN=$TESLA_VIN
 echo MQTT_IP=$MQTT_IP
 echo MQTT_PORT=$MQTT_PORT
 echo MQTT_USER=$MQTT_USER
@@ -43,7 +43,7 @@ echo SEND_CMD_RETRY_DELAY=$SEND_CMD_RETRY_DELAY
 echo BLE_MAC=$BLE_MAC
 
 docker-compose up -d \
-	-e VIN=$VIN \
+	-e TESLA_VIN=$TESLA_VIN \
 	-e MQTT_IP=$MQTT_IP \
 	-e MQTT_PORT=$MQTT_PORT \
 	-e MQTT_USER=$MQTT_USER \

--- a/tesla_ble_mqtt/README.md
+++ b/tesla_ble_mqtt/README.md
@@ -31,7 +31,7 @@ Note that in both cases below, if you have already created a key pair that you w
 2.2 For the standalone version, it has been tested on RPi 3B so far. Here are the assumptions and way forward:
 - You already have Docker working on the host device, and you are familiar with basic Docker concepts and actions
 - Clone the self packaged shell script: `https://github.com/raphmur/tesla-local-control-addon/blob/main/standalone/start_tesla_ble_mqtt.sh`
-- Edit the script to input your own settings: VIN, MQTT_IP (ip of your MQTT server), MQTT_PORT, MQTT_USER, MQTT_PWD, _optional_ _SEND_CMD_RETRY_DELAY_ (delay between retries in case BLE fails), _optional_ _BLE_MAC_ (to be used for proximity discovery)
+- Edit the script to input your own settings: TESLA_VIN, MQTT_IP (ip of your MQTT server), MQTT_PORT, MQTT_USER, MQTT_PWD, _optional_ _SEND_CMD_RETRY_DELAY_ (delay between retries in case BLE fails), _optional_ _BLE_MAC_ (to be used for proximity discovery)
 - run the script: `./start_tesla_ble_mqtt.sh`, it will download the rest of the elements, build and deploy the container
 
 3 THEN:

--- a/tesla_ble_mqtt/config.yaml
+++ b/tesla_ble_mqtt/config.yaml
@@ -1,5 +1,5 @@
 name: "Tesla Local Commands"
-version: "0.0.2a"
+version: "0.0.2b"
 slug: "tesla_local_commands"
 description: "Local BLE calls to control your Tesla."
 # url: "tbc"

--- a/tesla_ble_mqtt/rootfs/app/run.sh
+++ b/tesla_ble_mqtt/rootfs/app/run.sh
@@ -4,7 +4,7 @@ set -e
 
 # read options in case of HA addon. Otherwise, they will be sent as environment variables
 if [ -n "${HASSIO_TOKEN:-}" ]; then
-  VIN="$(bashio::config 'vin')"; export VIN
+  TESLA_VIN="$(bashio::config 'vin')"; export TESLA_VIN
   MQTT_IP="$(bashio::config 'mqtt_ip')"; export MQTT_IP
   MQTT_PORT="$(bashio::config 'mqtt_port')"; export MQTT_PORT
   MQTT_USER="$(bashio::config 'mqtt_user')"; export MQTT_USER
@@ -16,7 +16,7 @@ echo "Inspiration by Raphael Murray https://github.com/raphmur"
 echo "Instructions by Shankar Kumarasamy https://shankarkumarasamy.blog/2024/01/28/tesla-developer-api-guide-ble-key-pair-auth-and-vehicle-commands-part-3"
 
 echo "Configuration Options are:"
-echo TESLA_VIN=$VIN
+echo TESLA_VIN=$TESLA_VIN
 echo MQTT_IP=$MQTT_IP
 echo MQTT_PORT=$MQTT_PORT
 echo MQTT_USER=$MQTT_USER
@@ -32,7 +32,7 @@ fi
 send_command() {
  for i in $(seq 5); do
   echo "Attempt $i/5"
-  tesla-control -ble -vin $VIN -key-name /share/tesla_ble_mqtt/private.pem -key-file /share/tesla_ble_mqtt/private.pem $1
+  tesla-control -ble -key-name /share/tesla_ble_mqtt/private.pem -key-file /share/tesla_ble_mqtt/private.pem $1
   if [ $? -eq 0 ]; then
     echo "Ok"
     break


### PR DESCRIPTION
Per the tesla-control help:

```
$ tesla-control --help 2>&1 |grep -B1 TESLA_VIN
  -vin string
    	Vehicle Identification Number. Defaults to $TESLA_VIN.
```