### PR TITLE
Update BLE_MAC description

### DIFF
--- a/tesla_ble_mqtt/DOCS.md
+++ b/tesla_ble_mqtt/DOCS.md
@@ -16,7 +16,7 @@ If you have already created a key pair that you want to reuse, place the private
 
 You will need to provide:
 - TESLA_VIN (car VIN)
-- BLE_MAC: Used for proximity discovery. Tesla's BLE MAC starts with "S" and ends with "C". To find the address, use "BLE scanner" on Android or "nRF Connect" on iOS.
+- BLE_MAC: Used for proximity discovery. Tesla's BLE MAC is in the form AA:BB:CC:DD:EE:FF, or you can use the BLE Device name which starts with "S" and ends with "C". To find the address, use "BLE scanner" on Android or "nRF Connect" on iOS.
 - MQTT_IP: ip of your MQTT server
 - MQTT_PORT
 - MQTT_USER

--- a/tesla_ble_mqtt/DOCS.md
+++ b/tesla_ble_mqtt/DOCS.md
@@ -16,7 +16,7 @@ If you have already created a key pair that you want to reuse, place the private
 
 You will need to provide:
 - TESLA_VIN (car VIN)
-- BLE_MAC: Used for proximity discovery. Tesla's BLE MAC is in the form AA:BB:CC:DD:EE:FF, or you can use the BLE Device name which starts with "S" and ends with "C". To find the address, use "BLE scanner" on Android or "nRF Connect" on iOS.
+- BLE_MAC: Used for proximity discovery. Tesla's BLE MAC is in the form AA:BB:CC:DD:EE:FF. To find the address, use "BLE scanner" on Android or "nRF Connect" on iOS and look for a device with a name starting with "S" and ending with "C".
 - MQTT_IP: ip of your MQTT server
 - MQTT_PORT
 - MQTT_USER

--- a/tesla_ble_mqtt/config.yaml
+++ b/tesla_ble_mqtt/config.yaml
@@ -1,5 +1,5 @@
 name: "Tesla Local Commands"
-version: "0.0.8"
+version: "0.0.8a"
 slug: "tesla_local_commands"
 description: "Local BLE calls to control your Tesla."
 # url: "tbc"

--- a/tesla_ble_mqtt/translations/en.yaml
+++ b/tesla_ble_mqtt/translations/en.yaml
@@ -16,7 +16,7 @@ configuration:
     description: Vehicle Identification Number found in Tesla app
   ble_mac:
     name: BLE MAC (optional for proximity detection)
-    description: Car's BLE MAC (S___________C); Use Android "BLE scanner" or iOS "nRF Connect"
+    description: Car's BLE MAC (aa:bb:cc:dd:ee:ff) or BLE Device name (S___________C); Use Android "BLE scanner" or iOS "nRF Connect"
   debug:
     name: Debug Logging
     description: Print verbose messages to the log for debugging

--- a/tesla_ble_mqtt/translations/en.yaml
+++ b/tesla_ble_mqtt/translations/en.yaml
@@ -16,7 +16,7 @@ configuration:
     description: Vehicle Identification Number found in Tesla app
   ble_mac:
     name: BLE MAC (optional for proximity detection)
-    description: Car's BLE MAC (aa:bb:cc:dd:ee:ff) or BLE Device name (S___________C); Use Android "BLE scanner" or iOS "nRF Connect"
+    description: Car's BLE MAC (aa:bb:cc:dd:ee:ff). Use Android "BLE scanner" or iOS "nRF Connect" to find the MAC of the Tesla BLE Device which looks like S___________C
   debug:
     name: Debug Logging
     description: Print verbose messages to the log for debugging

--- a/tesla_ble_mqtt/translations/fr.yaml
+++ b/tesla_ble_mqtt/translations/fr.yaml
@@ -16,7 +16,7 @@ configuration:
     description: Numéro d'Identification de Véhicule affiché dans l'application Tesla
   ble_mac:
     name: BLE MAC (optionnel pour détection de proximité)
-    description: BLE MAC (S___________C) du véhicule; Utiliser Android "BLE scanner" ou iOS "nRF Connect"
+    description: Adresse MAC BLE (aa:bb:cc:dd:ee:ff) ou Nom BLE  (S___________C) du véhicule"; Utiliser Android "BLE scanner" ou iOS "nRF Connect
   debug:
     name: Journalisation du débogage
     description: Imprimer des messages détaillés dans le journal pour le débogage

--- a/tesla_ble_mqtt/translations/fr.yaml
+++ b/tesla_ble_mqtt/translations/fr.yaml
@@ -16,7 +16,7 @@ configuration:
     description: Numéro d'Identification de Véhicule affiché dans l'application Tesla
   ble_mac:
     name: BLE MAC (optionnel pour détection de proximité)
-    description: Adresse MAC BLE (aa:bb:cc:dd:ee:ff) ou Nom BLE  (S___________C) du véhicule"; Utiliser Android "BLE scanner" ou iOS "nRF Connect
+    description: Adresse MAC BLE (aa:bb:cc:dd:ee:ff). Utiliser Android "BLE scanner" ou iOS "nRF Connect" pour trouver l'adresse MAC Tesla associée au nom BLE ressemblant à S___________C
   debug:
     name: Journalisation du débogage
     description: Imprimer des messages détaillés dans le journal pour le débogage


### PR DESCRIPTION
Until it is removed, it should be described properly.
Linked to #20