### PR TITLE
[v0.0.9 - ready] Find MAC address automatically + add option to deactivate proximity scanner

### DIFF
--- a/standalone/start_tesla_ble_mqtt.sh
+++ b/standalone/start_tesla_ble_mqtt.sh
@@ -8,8 +8,9 @@ MQTT_PORT=1883
 MQTT_USER=""
 MQTT_PWD=""
 SEND_CMD_RETRY_DELAY=5
-BLE_MAC=00:00:00:00:00:00
 DEBUG="false"
+PRESENCE_DETECTION="false"
+BLE_MAC=""
 ############################################################
 
 
@@ -42,8 +43,9 @@ echo "Start main docker container with configuration Options:
   MQTT_USER=$MQTT_USER
   MQTT_PWD=Not Shown
   SEND_CMD_RETRY_DELAY=$SEND_CMD_RETRY_DELAY
-  BLE_MAC=$BLE_MAC
-  DEBUG=$DEBUG"
+  DEBUG=$DEBUG
+  PRESENCE_DETECTION=$PRESENCE_DETECTION
+  BLE_MAC=$BLE_MAC"
 
 docker-compose up -d \
   -e TESLA_VIN=$TESLA_VIN \
@@ -52,5 +54,6 @@ docker-compose up -d \
   -e MQTT_USER=$MQTT_USER \
   -e MQTT_PWD=$MQTT_PWD \
   -e SEND_CMD_RETRY_DELAY=$SEND_CMD_RETRY_DELAY \
-  -e BLE_MAC=$BLE_MAC \
-  -e DEBUG=$DEBUG
+  -e DEBUG=$DEBUG \
+  -e PRESENCE_DETECTION=$PRESENCE_DETECTION \
+  -e BLE_MAC=$BLE_MAC

--- a/tesla_ble_mqtt/CHANGELOG.md
+++ b/tesla_ble_mqtt/CHANGELOG.md
@@ -1,5 +1,12 @@
 <!-- https://developers.home-assistant.io/docs/add-ons/presentation#keeping-a-changelog -->
 
+## 0.0.9
+
+### Changed
+
+- Add option to deactivate BLE proximity scanner (by default, periodicity is around 4 min)
+- Implement MAC address detection from VIN (MAC can still be input if prefered)
+
 ## 0.0.8
 
 ### Changed

--- a/tesla_ble_mqtt/Dockerfile
+++ b/tesla_ble_mqtt/Dockerfile
@@ -19,7 +19,8 @@ RUN apk add --no-cache \
   openssl \
   bluez \
   mosquitto-clients \
-  python3
+  python3 \
+  py-cryptography
 
 # Python 3 HTTP Server serves the current working dir
 WORKDIR /data

--- a/tesla_ble_mqtt/config.yaml
+++ b/tesla_ble_mqtt/config.yaml
@@ -1,5 +1,5 @@
 name: "Tesla Local Commands local"
-version: "0.0.8b"
+version: "0.0.9"
 slug: "tesla_local_commands"
 description: "Local BLE calls to control your Tesla."
 # url: "tbc"
@@ -19,6 +19,7 @@ map:
 startup: services
 options:
   vin: ""
+  presence_detection: false
   ble_mac: ""
   debug: false
   mqtt_ip: ""
@@ -29,6 +30,7 @@ options:
 schema:
   vin: str?
   debug: bool
+  presence_detection: bool
   ble_mac: str?
   mqtt_ip: str?
   mqtt_port: str?

--- a/tesla_ble_mqtt/config.yaml
+++ b/tesla_ble_mqtt/config.yaml
@@ -1,5 +1,5 @@
-name: "Tesla Local Commands"
-version: "0.0.8"
+name: "Tesla Local Commands local"
+version: "0.0.8b"
 slug: "tesla_local_commands"
 description: "Local BLE calls to control your Tesla."
 # url: "tbc"

--- a/tesla_ble_mqtt/rootfs/app/calc_ble_from_vin.sh
+++ b/tesla_ble_mqtt/rootfs/app/calc_ble_from_vin.sh
@@ -1,0 +1,66 @@
+#!/bin/bash
+
+# Generate BLE_MAC from TESLA_VIN
+bashio::log.notice "TESLA_VIN: $TESLA_VIN. Calculating BLE_LOCAL_NAME..."
+
+function ble_mac_generate() {
+python3 - << __END_PY__
+from cryptography.hazmat.primitives import hashes;
+vin = bytes("$TESLA_VIN", "UTF8");
+digest = hashes.Hash(hashes.SHA1())
+digest.update(vin)
+vinSHA = digest.finalize().hex()
+middleSection = vinSHA[0:16]
+bleName = "S" + middleSection + "C"
+print(bleName)
+__END_PY__
+}
+
+BLE_LOCAL_NAME=$(ble_mac_generate)
+
+
+
+# print BLE Local Name for which we want the MAC
+bashio::log.notice "BLE_LOCAL_NAME: $BLE_LOCAL_NAME. Start MAC finding..."
+
+# scan and store the list of found MACs, list is provided after timeout
+bluetoothctl --timeout 30 scan on | grep -o -E '([[:xdigit:]]{1,2}:){5}[[:xdigit:]]{1,2}' > scan-macs.txt
+sort scan-macs.txt | uniq > uniq_macs.txt
+
+# print the list of MACs we found
+bashio::log.info "Found MACS:"
+cat uniq_macs.txt
+
+# start scan again in another process so we can get the detailed info for each MAC
+bluetoothctl --timeout 20 scan on > /dev/zero &
+
+#xargs -0 -n 1 bluetoothctl info  < <(tr \\n \\0 <scan-macs.txt) | grep "Name: $BLE_LOCAL_NAME"
+
+# cycle through all scanned MACs to find our MAC
+BLE_MAC=""
+while read mac; do
+        INFO=$(bluetoothctl --timeout 1 info $mac)
+        INFONAME=$(echo "$INFO" | grep "Name: $BLE_LOCAL_NAME")
+
+        if [[ -n $INFONAME ]]; then
+                bashio::log.info "Found Tesla $TESLA_VIN's MAC:"
+                echo $mac > mac.txt
+                INFORSSI=$(echo "$INFO" | grep "RSSI: ")
+                bashio::log.info "$mac"
+                bashio::log.info "$INFONAME"
+                bashio::log.info "$INFORSSI"
+				BLE_MAC="$mac"
+				# kill bluetoothctl
+				# killall `ps -aux | grep bluetoothctl | grep -v grep | awk '{ print $1 }'`
+				break
+        fi
+done < uniq_macs.txt
+
+
+if [ -z ${BLE_MAC-} ]; then
+ bashio::log.info "No corresponding MAC address found: is the car close to the BLE device?"
+ bashio::log.info "Will retry later"
+else
+ bashio::log.info "End MAC finding: success $BLE_MAC"
+ export BLE_MAC
+fi

--- a/tesla_ble_mqtt/translations/en.yaml
+++ b/tesla_ble_mqtt/translations/en.yaml
@@ -20,6 +20,9 @@ configuration:
   debug:
     name: Debug Logging
     description: Print verbose messages to the log for debugging
+  presence_detection:
+    name: Proximity detector
+    description: Scan for vehicle proximity to the bluetooth device
   send_cmd_retry_delay:
     name: Delay to retry a command
     description: Delay to retry sending a command to the vehicle over BLE

--- a/tesla_ble_mqtt/translations/fr.yaml
+++ b/tesla_ble_mqtt/translations/fr.yaml
@@ -20,6 +20,9 @@ configuration:
   debug:
     name: Journalisation du débogage
     description: Imprimer des messages détaillés dans le journal pour le débogage
+  presence_detection:
+    name: Détecteur de présence
+    description: Détecter la présence du véhicule, à portée de l'appareil bluetooth
   send_cmd_retry_delay:
     name: Délai pour re-essayer une commande
     description: Délai pour re-essayer d'envoyer une command au véhicule via BLE


### PR DESCRIPTION
**Implement dedicated function to find MAC from VIN:**
- Derive BLE LNAME from VIN using sha1sum. I cannot find origin post about this, though [documented here in python](https://teslabtapi.lexnastin.com/docs/start#vehicle-ble-name)
- Find MAC address using bluetoothctl scan. Credit to [BogdanDIA](https://github.com/iainbullock/tesla_ble_mqtt_docker/issues/10#issuecomment-2180018678)

**Add option to activate/deactivate proximity sensing.**

Rule:
- if proximity sensing is activated and BLE_MAC is defined to a non empty string the `listen_to_ble` function will be called as in v0.0.8
- if proximity sensing is activated and BLE_MAC is not defined or is empty string the `calc_ble_from_vin` will be used to find the mac address to enable calls to `listen_to_ble`. It is tried at container startup and periodically if the MAC cannot be detected.
- if proximity sensing is deactivated, none of the above is done